### PR TITLE
feat: add configurability using a configuration file

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -78,8 +78,8 @@ func proxy(log logr.Logger, to net.Conn, from net.Conn, quitChan <-chan struct{}
 
 type Option func(b *Backend)
 
-func NewBackend(network string, addr string, log logr.Logger, opts ...Option) Backend {
-	b := Backend{
+func NewBackend(network string, addr string, log logr.Logger, opts ...Option) *Backend {
+	b := &Backend{
 		Addr:    addr,
 		Network: network,
 		log:     log,
@@ -87,7 +87,7 @@ func NewBackend(network string, addr string, log logr.Logger, opts ...Option) Ba
 	}
 
 	for _, opt := range opts {
-		opt(&b)
+		opt(b)
 	}
 
 	return b

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type APIVersion string
+
+const (
+	APIVersionV1 APIVersion = "v1"
+)
+
+type Config struct {
+	// APIVersion specifies the version of the configuration file used when it was persisted. This field doesn't
+	// have any impact at the moment but provides forward-compatibility when a backwards-incompatible change has
+	// to be applied to the configuration in which case this version is increased.
+	APIVersion APIVersion `yaml:"apiVersion"`
+	Frontends  []Frontend `yaml:"frontends"`
+}
+
+type Frontend struct {
+	Bind           string    `yaml:"bind"`
+	Backends       []Backend `yaml:"backends"`
+	HealthInterval int       `yaml:"healthInterval"`
+}
+
+type Backend struct {
+	Address string `yaml:"address"`
+}
+
+func Read(cfgPath string) (*Config, error) {
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read configuration file %q: %w", cfgPath, err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse configuration file %q: %w", cfgPath, err)
+	}
+
+	return &cfg, nil
+}

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -1,0 +1,121 @@
+package frontend
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/makkes/l4proxy/backend"
+)
+
+type Frontend struct {
+	BindNetwork string
+	BindHost    string
+	BindPort    string
+	Log         logr.Logger
+	Backends    []*backend.Backend
+}
+
+type Option func(f *Frontend)
+
+func NewFrontend(network, bind string, log logr.Logger, opts ...Option) (Frontend, error) {
+	var f Frontend
+	bindHost, bindPort, err := parseHostPort(bind)
+	if err != nil {
+		return f, fmt.Errorf("error parsing frontend bind spec: %w", err)
+	}
+	f.BindNetwork = network
+	f.BindHost = bindHost
+	f.BindPort = bindPort
+	f.Log = log
+
+	for _, opt := range opts {
+		opt(&f)
+	}
+
+	return f, nil
+}
+
+func parseHostPort(hp string) (string, string, error) {
+	parts := strings.SplitN(hp, ":", 2)
+	if len(parts) == 0 {
+		return "", "", fmt.Errorf("wrong format of bind spec '%s'. Expected [host:]port", hp)
+	}
+	var host, port string
+	switch len(parts) {
+	case 1:
+		host = ""
+		port = parts[0]
+	case 2:
+		if parts[1] == "" {
+			return "", "", fmt.Errorf("bind spec '%s' is missing a port", hp)
+		} else {
+			host = parts[0]
+			port = parts[1]
+		}
+	}
+
+	return host, port, nil
+}
+
+func (f *Frontend) AddBackend(be string, healthInterval int) error {
+	host, port, err := parseHostPort(be)
+	if err != nil {
+		return fmt.Errorf("backend spec '%s' has errors: %w", be, err)
+	}
+
+	backend := backend.NewBackend("tcp4", fmt.Sprintf("%s:%s", host, port), f.Log)
+	backend.Start(healthInterval)
+	f.Backends = append(f.Backends, backend)
+
+	return nil
+}
+
+func (f Frontend) Start() {
+	listenAddr, err := net.ResolveTCPAddr("tcp4", fmt.Sprintf("%s:%s", f.BindHost, f.BindPort))
+	if err != nil {
+		f.Log.Error(err, "cannot parse listening address", "host", f.BindHost, "port", f.BindPort)
+		return
+	}
+	ln, err := net.ListenTCP("tcp4", listenAddr)
+	if err != nil {
+		f.Log.Error(err, "cannot start listener", "addr", listenAddr)
+		return
+	}
+
+	for {
+		conn, err := ln.AcceptTCP()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error accepting connection: %s", err)
+			continue
+		}
+		ctx, _ := context.WithTimeout(context.Background(), 30*time.Second) // nolint:govet // this is an endless loop
+		go handleConn(ctx, f.Log, *conn, f.Backends)
+	}
+}
+
+func handleConn(ctx context.Context, log logr.Logger, cconn net.TCPConn, backends []*backend.Backend) {
+	idcs := make([]int, len(backends))
+	for idx := range backends {
+		idcs[idx] = idx
+	}
+	rand.Shuffle(len(idcs), func(i, j int) {
+		idcs[i], idcs[j] = idcs[j], idcs[i]
+	})
+	for _, idx := range idcs {
+		if backends[idx].Healthy != nil && *backends[idx].Healthy {
+			log.V(4).Info("selecting backend", "backend", backends[idx])
+			backends[idx].HandleConn(ctx, &cconn)
+			return
+		}
+		log.V(4).Info("skipping unhealthy backend", "backend", backends[idx])
+	}
+	log.Error(nil, "all backends are unhealthy")
+	cconn.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,11 @@ module github.com/makkes/l4proxy
 go 1.15
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/glogr v0.2.0
 	github.com/go-logr/logr v0.3.0
 	github.com/go-logr/stdr v0.3.0
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/golang/glog v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/glogr v0.2.0 h1:/ZM6L79do5HYpTyBEtvjDcjlROWbATWEsoZXX3aJOFk=
 github.com/go-logr/glogr v0.2.0/go.mod h1:GDQ2+z9PAAX7+qBhL3FzAL2Nf8dxyliu0ppgJIX7YhU=
 github.com/go-logr/logr v0.3.0 h1:q4c+kbcR0d5rSurhBR8dIgieOaYpXtsdTYfx22Cu6rs=
 github.com/go-logr/logr v0.3.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/stdr v0.3.0 h1:GzFt/sOHlPMqsh46UTAaIDWPFq3DdNGcF4rwMjhTBVo=
 github.com/go-logr/stdr v0.3.0/go.mod h1:NO1vneyJDqKVgJYnxhwXWWmQPOvNM391IG3H8ql3jiA=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -18,6 +17,5 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/l4proxy_example.yaml
+++ b/l4proxy_example.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+frontends:
+  - bind: :1313
+    healthInterval: 5
+    backends:
+      - address: localhost:1314
+      - address: localhost:1315

--- a/main.go
+++ b/main.go
@@ -1,102 +1,63 @@
 package main
 
 import (
-	"context"
+	"encoding/json"
 	goflag "flag"
 	"fmt"
 	"math/rand"
-	"net"
+	"net/http"
 	"os"
 	"runtime"
-	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/glogr"
 	"github.com/go-logr/logr"
 	flag "github.com/spf13/pflag"
 
-	"github.com/makkes/l4proxy/backend"
+	"github.com/makkes/l4proxy/config"
+	"github.com/makkes/l4proxy/frontend"
 )
 
-func handleConn(ctx context.Context, log logr.Logger, cconn net.TCPConn, backends []*backend.Backend) {
-	idcs := make([]int, len(backends))
-	for idx := range backends {
-		idcs[idx] = idx
-	}
-	rand.Shuffle(len(idcs), func(i, j int) {
-		idcs[i], idcs[j] = idcs[j], idcs[i]
-	})
-	for _, idx := range idcs {
-		if backends[idx].Healthy != nil && *backends[idx].Healthy {
-			log.V(4).Info("selecting backend", "backend", backends[idx])
-			backends[idx].HandleConn(ctx, &cconn)
-			return
+func startWebServer(log logr.Logger) {
+	http.HandleFunc("/backends", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			var body map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				log.V(4).Info("could not unmarshal payload", "err", err.Error())
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprintf(w, "%s\n", err.Error())
+				return
+			}
+			// fmt.Printf("%#v\n", body)
 		}
-		log.V(4).Info("skipping unhealthy backend", "backend", backends[idx])
-	}
-	log.Error(nil, "all backends are unhealthy")
-	cconn.Close()
+	})
+	http.ListenAndServe("127.0.0.1:1313", nil)
 }
 
 func main() {
 	rand.Seed(time.Now().UnixNano())
 
-	var listenHost string
-	flag.StringVar(&listenHost, "host", "127.0.0.1", "the host to listen on")
-	var listenPort string
-	flag.StringVar(&listenPort, "port", "9999", "the port to listen on")
-	var backendsFlag []string
-	flag.StringSliceVar(&backendsFlag, "backends", nil, "comma-separated list of backend(s) to forward traffic to. Format [host:]port")
-	var healthInterval int
-	flag.IntVar(&healthInterval, "health-interval", 15, "how often (in seconds) to check for each backend's health")
+	var configFile string
+	flag.StringVarP(&configFile, "config", "c", "", "configuration file ")
 
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.Set("v", "1")
 	flag.Set("logtostderr", "true")
-
 	flag.Parse()
 
+	if configFile == "" {
+		fmt.Fprintf(os.Stderr, "no config file provided, exiting.\n")
+		os.Exit(1)
+	}
+
+	cfg, err := config.Read(configFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not read config file: %s\n", err.Error())
+		os.Exit(1)
+	}
+
 	log := glogr.New()
-
-	listenAddr, err := net.ResolveTCPAddr("tcp4", fmt.Sprintf("%s:%s", listenHost, listenPort))
-	if err != nil {
-		log.Error(err, "cannot parse listening address", "host", listenHost, "port", listenPort)
-		os.Exit(1)
-	}
-	ln, err := net.ListenTCP("tcp4", listenAddr)
-	if err != nil {
-		log.Error(err, "cannot start listener", "addr", listenAddr)
-		os.Exit(1)
-	}
-
-	backends := make([]*backend.Backend, 0)
-	for _, be := range backendsFlag {
-		parts := strings.SplitN(be, ":", 2)
-		if len(parts) == 0 {
-			log.Error(nil, "wrong format of backend spec", "spec", be)
-			os.Exit(1)
-		}
-		var host, port string
-		switch len(parts) {
-		case 1:
-			host = ""
-			port = parts[0]
-		case 2:
-			if parts[1] == "" {
-				log.Error(nil, "backend spec is missing a port", "spec", be)
-				os.Exit(1)
-			} else {
-				host = parts[0]
-				port = parts[1]
-			}
-		}
-
-		backend := backend.NewBackend("tcp4", fmt.Sprintf("%s:%s", host, port), log)
-		backend.Start(healthInterval)
-		backends = append(backends, &backend)
-	}
-
-	log.V(1).Info("listener started", "address", listenAddr.String(), "backends", backends)
 
 	debug := os.Getenv("DEBUG")
 	if debug != "" {
@@ -108,13 +69,37 @@ func main() {
 		}()
 	}
 
-	for {
-		conn, err := ln.AcceptTCP()
+	go startWebServer(log)
+
+	frontends := make([]frontend.Frontend, 0)
+	for _, feCfg := range cfg.Frontends {
+		fe, err := frontend.NewFrontend("tcp", feCfg.Bind, log)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error accepting connection: %s", err)
-			continue
+			fmt.Fprintf(os.Stderr, "error creating frontend: %s\n", err.Error())
+			os.Exit(1)
 		}
-		ctx, _ := context.WithTimeout(context.Background(), 30*time.Second) // nolint:govet
-		go handleConn(ctx, log, *conn, backends)
+		for _, beCfg := range feCfg.Backends {
+			if err := fe.AddBackend(beCfg.Address, feCfg.HealthInterval); err != nil {
+				fmt.Fprintf(os.Stderr, "error adding backend '%s': %s\n", beCfg.Address, err.Error())
+				os.Exit(1)
+			}
+		}
+		frontends = append(frontends, fe)
 	}
+
+	var wg sync.WaitGroup
+
+	for idx := range frontends {
+		wg.Add(1)
+		go func(idx int) {
+			frontends[idx].Start()
+			wg.Done()
+		}(idx)
+	}
+
+	log.Info("all frontends running", "frontends", len(frontends))
+
+	wg.Wait()
+
+	log.Info("all frontends quit")
 }


### PR DESCRIPTION
This is a major re-work of how l4proxy is configured. I moved away
from pure CLI flags to a configuration file.

It's now possible to configure multiple frontends at once, each
serving from one or more backends.