### PR TITLE
feat: add Frontend.Stop; avoid race conditions

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -21,9 +22,10 @@ type Backend struct {
 	Network string `json:"network"`
 	log     logr.Logger
 	LastErr error `json:"lastErr"`
-	Healthy *bool `json:"healthy"`
+	healthy *bool
 	stopCh  chan struct{}
 	proxy   proxyFunc
+	mux     sync.RWMutex
 }
 
 func proxy(log logr.Logger, to net.Conn, from net.Conn, quitChan <-chan struct{}) <-chan struct{} {
@@ -99,6 +101,13 @@ func WithProxyFunc(f proxyFunc) Option {
 	}
 }
 
+func (b *Backend) IsHealthy() bool {
+	b.mux.RLock()
+	healthy := b.healthy != nil && *b.healthy
+	b.mux.RUnlock()
+	return healthy
+}
+
 func (b *Backend) Start(interval int) {
 	b.stopCh = make(chan struct{})
 	go func() {
@@ -108,7 +117,6 @@ func (b *Backend) Start(interval int) {
 			select {
 			case <-b.stopCh:
 				ticker.Stop()
-				b.stopCh = nil
 				return
 			case <-ticker.C:
 				b.checkHealth()
@@ -117,7 +125,7 @@ func (b *Backend) Start(interval int) {
 	}()
 }
 
-func (b Backend) Stop() {
+func (b *Backend) Stop() {
 	if b.stopCh == nil {
 		// not running
 		return
@@ -125,18 +133,15 @@ func (b Backend) Stop() {
 	close(b.stopCh)
 }
 
-func (b *Backend) HandleConn(ctx context.Context, c net.Conn) {
+func (b *Backend) HandleConn(ctx context.Context, c net.Conn) error {
 	b.log.V(3).Info("handling incoming connection", "remote", c.RemoteAddr().String())
 	defer c.Close()
 	var dialer net.Dialer
 	beconn, err := dialer.DialContext(ctx, b.Network, b.Addr)
 	if err != nil {
-		b.Healthy = BoolPtr(false)
-		b.LastErr = err
-		b.log.Error(err, "error dialing backend")
-		return
+		b.setHealth(false, err)
+		return fmt.Errorf("error dialing backend %s %s: %w", b.Network, b.Addr, err)
 	}
-	b.Healthy = BoolPtr(true)
 
 	quitChan := make(chan struct{})
 	beDirChan := b.proxy(b.log, beconn, c, quitChan)
@@ -153,33 +158,39 @@ func (b *Backend) HandleConn(ctx context.Context, c net.Conn) {
 	select {
 	case <-ctx.Done():
 		close(quitChan)
-		return
+		return nil
 	case <-beDirChan:
 		close(quitChan)
-		return
+		return nil
 	case <-clDirChan:
 		close(quitChan)
-		return
+		return nil
 	}
+}
+
+func (b *Backend) setHealth(healthy bool, err error) {
+	b.mux.Lock()
+	b.healthy = BoolPtr(healthy)
+	b.LastErr = err
+	b.mux.Unlock()
 }
 
 func (b *Backend) checkHealth() {
 	b.log.V(5).Info("checking health", "backend", b)
 	conn, err := net.Dial(b.Network, b.Addr)
 	if err != nil {
-		b.LastErr = err
-		if b.Healthy == nil || *b.Healthy {
+		if b.healthy == nil || *b.healthy {
 			b.log.V(2).Info("backend got unhealthy", "backend", b)
 		}
-		b.Healthy = BoolPtr(false)
+		b.setHealth(false, err)
+
 		return
 	}
 	if err := conn.Close(); err != nil {
-		b.LastErr = err
-		b.Healthy = BoolPtr(false)
+		b.setHealth(false, err)
 	}
-	if b.Healthy == nil || !*b.Healthy {
+	if b.healthy == nil || !*b.healthy {
 		b.log.V(2).Info("backend got healthy", "backend", b.Addr)
 	}
-	b.Healthy = BoolPtr(true)
+	b.setHealth(true, nil)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -17,18 +17,18 @@ type Config struct {
 	// APIVersion specifies the version of the configuration file used when it was persisted. This field doesn't
 	// have any impact at the moment but provides forward-compatibility when a backwards-incompatible change has
 	// to be applied to the configuration in which case this version is increased.
-	APIVersion APIVersion `yaml:"apiVersion"`
-	Frontends  []Frontend `yaml:"frontends"`
+	APIVersion APIVersion `yaml:"apiVersion" json:"apiVersion"`
+	Frontends  []Frontend `yaml:"frontends" json:"frontends"`
 }
 
 type Frontend struct {
-	Bind           string    `yaml:"bind"`
-	Backends       []Backend `yaml:"backends"`
-	HealthInterval int       `yaml:"healthInterval"`
+	Bind           string    `yaml:"bind" json:"bind"`
+	Backends       []Backend `yaml:"backends" json:"backends"`
+	HealthInterval int       `yaml:"healthInterval" json:"healthInterval"`
 }
 
 type Backend struct {
-	Address string `yaml:"address"`
+	Address string `yaml:"address" json:"address"`
 }
 
 func Read(cfgPath string) (*Config, error) {


### PR DESCRIPTION
* Frontend.Start now returns and start the listener in a goroutine.
* Frontend.Stop stops the frontend and all goroutines that Start
  started.
* Backend health checking is now thread-safe.