### PR TITLE
feat: support multiple config files

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func (p *L4Proxy) Start() {
 
 	p.frontends = frontends
 
-	p.log.V(5).Info("all frontends running")
+	p.log.Info("all frontends running")
 }
 
 func (p *L4Proxy) Stop() {
@@ -65,52 +65,65 @@ func (p *L4Proxy) Stop() {
 func main() {
 	rand.Seed(time.Now().UnixNano())
 
-	var configFile string
-	flag.StringVarP(&configFile, "config", "c", "", "configuration file ")
+	var configFiles []string
+	flag.StringSliceVarP(&configFiles, "config", "c", nil, "configuration files")
 
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.Set("v", "1")
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
-	if configFile == "" {
+	if len(configFiles) == 0 {
 		fmt.Fprintf(os.Stderr, "no config file provided, exiting.\n")
 		os.Exit(1)
 	}
 
 	log := glogr.New()
 
-	cfgFileUpdateCh := make(chan struct{})
+	cfgFileUpdateCh := make(chan string)
 
-	go func(updateCh chan<- struct{}) {
-		var lastModTime time.Time
-		ticker := time.NewTicker(3 * time.Second)
-		for range ticker.C {
-			cfgFile, err := os.Stat(configFile)
-			if err != nil {
-				log.Error(err, "failed to stat configuration file for modification checking")
-				continue
+	for _, configFile := range configFiles {
+		cfgFileLog := log.WithValues("config_file", configFile)
+		go func(updateCh chan<- string, configFile string, log logr.Logger) {
+			var lastModTime time.Time
+			ticker := time.NewTicker(3 * time.Second)
+			for range ticker.C {
+				cfgFile, err := os.Stat(configFile)
+				if err != nil {
+					log.Error(err, "failed to stat configuration file for modification checking")
+					continue
+				}
+				if cfgFile.ModTime().After(lastModTime) {
+					lastModTime = cfgFile.ModTime()
+					updateCh <- configFile
+				}
 			}
-			if cfgFile.ModTime().After(lastModTime) {
-				lastModTime = cfgFile.ModTime()
-				updateCh <- struct{}{}
-			}
-		}
-	}(cfgFileUpdateCh)
+		}(cfgFileUpdateCh, configFile, cfgFileLog)
+	}
 
-	go func(cfgFileUpdateCh <-chan struct{}) {
-		var proxy L4Proxy
-		for range cfgFileUpdateCh {
-			log.V(2).Info("config file update, reloading configuration")
-			cfg, err := config.Read(configFile)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "could not read config file: %s\n", err.Error())
-				continue
+	go func(cfgFileUpdateCh <-chan string) {
+		proxies := make(map[string]*L4Proxy)
+		for cfgFileUpdate := range cfgFileUpdateCh {
+			for _, configFile := range configFiles {
+				if configFile != cfgFileUpdate {
+					continue
+				}
+				cfgFileLog := log.WithValues("config_file", configFile)
+				cfgFileLog.V(2).Info("config file update, reloading configuration")
+				cfg, err := config.Read(configFile)
+				if err != nil {
+					cfgFileLog.Error(err, "could not read config file")
+					continue
+				}
+				cfgFileLog.Info("restarting proxy")
+				p := proxies[configFile]
+				if p != nil {
+					p.Stop()
+				}
+				newProxy := NewL4Proxy(*cfg, cfgFileLog)
+				proxies[configFile] = &newProxy
+				newProxy.Start()
 			}
-			log.Info("stopping proxy")
-			proxy.Stop()
-			proxy = NewL4Proxy(*cfg, log)
-			proxy.Start()
 		}
 	}(cfgFileUpdateCh)
 


### PR DESCRIPTION
Being able to supply multiple configuration files is useful in
situations where one config file is maintained by automation (e.g.
service-announcer) and the other is maintained manually.