### PR TITLE
feat: improve timeout handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,11 +16,11 @@ jobs:
     - name: Get golangci-lint on Windows
       if: runner.os == 'Windows'
       shell: bash
-      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.50.1
+      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.52.2
     - name: Get golangci-lint on macOS and Linux
       if: runner.os == 'macOS' || runner.os == 'Linux'
       shell: bash
-      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v1.50.1
+      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v1.52.2
     - name: Lint code
       if: runner.os == 'macOS' || runner.os == 'Linux'
       run: make lint

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golangci-lint 1.50.1
-golang 1.19.2
+golangci-lint 1.52.2
+golang 1.20.3
 pre-commit 2.17.0


### PR DESCRIPTION
Whenever data is passed between client and backend, the timeout timer is reset so that long-lasting connections can now be established between clients and backends.

BREAKING CHANGE: The semantics of timeout handling are different now in that l4proxy now only closes a connection if no data has been passed between client and backend within 30s. Before, a connection has always been closed after 30s regardless of any data being transferred.  This may lead to more open connections going forward.
