### PR TITLE
feat: add configurable timeout per frontend

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use asdf

--- a/cmd/l4proxy/main.go
+++ b/cmd/l4proxy/main.go
@@ -31,7 +31,9 @@ func NewL4Proxy(cfg config.Config, log logr.Logger) L4Proxy {
 func (p *L4Proxy) Start() {
 	frontends := make([]*frontend.Frontend, 0)
 	for _, feCfg := range p.cfg.Frontends {
-		fe, err := frontend.NewFrontend("tcp", feCfg.Bind, p.log)
+		fe, err := frontend.NewFrontend("tcp", feCfg.Bind, p.log,
+			frontend.WithTimeout(feCfg.Timeout),
+		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error creating frontend: %s\n", err.Error())
 			os.Exit(1)

--- a/l4proxy/config/config.go
+++ b/l4proxy/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -22,9 +23,10 @@ type Config struct {
 }
 
 type Frontend struct {
-	Bind           string    `yaml:"bind" json:"bind"`
-	Backends       []Backend `yaml:"backends" json:"backends"`
-	HealthInterval int       `yaml:"healthInterval" json:"healthInterval"`
+	Bind           string        `yaml:"bind" json:"bind"`
+	Backends       []Backend     `yaml:"backends" json:"backends"`
+	HealthInterval int           `yaml:"healthInterval" json:"healthInterval"`
+	Timeout        time.Duration `yaml:"timeout" json:"timeout"`
 }
 
 type Backend struct {

--- a/l4proxy_example.yaml
+++ b/l4proxy_example.yaml
@@ -19,6 +19,6 @@ frontends:
   # bind: "@lo:1313"
   - bind: "@lo:1313"
     healthInterval: 5
+    timeout: 10s
     backends:
       - address: localhost:1314
-      - address: localhost:1315


### PR DESCRIPTION
The configuration file now allows to define a timeout for each frontend. This timeout specifies how much time must pass without any data being exchanged between client and (any) backend until the connection is closed.
